### PR TITLE
fix: opaque type is not Send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ prost = { version = "0.9" }
 protobuf = "2"
 raft-proto = { path = "proto", version = "0.7.0", default-features = false }
 rand = "0.8"
+serde = "1.0"
+serde_derive = "1.0"
 slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }
 slog-stdlog = { version = "4", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -20,9 +20,12 @@ prost-codec = ["prost", "tonic", "lazy_static"]
 prost-build = "0.9"
 tonic-build = "0.6.2"
 
+
 [dependencies]
 bytes = { version = "1", optional = true }
 lazy_static = { version = "1", optional = true }
 prost = { version = "0.9", optional = true }
 protobuf = "2"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"
 tonic = { version = "0.6.2", optional = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -2,6 +2,7 @@
 
 fn main() {
     tonic_build::configure()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile(&["proto/eraftpb.proto"], &["proto"])
         .unwrap()
 }

--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package eraftpb;
 
 enum EntryType {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,10 +30,11 @@ use crate::util::limit_size;
 
 use async_trait::async_trait;
 use getset::{Getters, Setters};
+use serde_derive::{Deserialize, Serialize};
 
 /// Holds both the hard state (commit index, vote leader, term) and the configuration state
 /// (Current node IDs)
-#[derive(Debug, Clone, Default, Getters, Setters)]
+#[derive(Debug, Clone, Default, Getters, Setters, Serialize, Deserialize)]
 pub struct RaftState {
     /// Contains the last meta information including commit index, the vote leader, and the vote term.
     pub hard_state: HardState,


### PR DESCRIPTION
As metioned in https://github.com/rust-lang/rust/issues/93458 , using `.await` in `format!` will cause `Future` not `Send`. We need to move `.await` output `format!` and `log!` scopes.

Changes:
- Move `.await` output `format!` and `log!` scopes.
- Add `serde::Serialize` and `serde::Deserialize` for proto structs.
- Fix `Snapshot::is_emtpy`.